### PR TITLE
Implement NAND browsing

### DIFF
--- a/include/nxsh.h
+++ b/include/nxsh.h
@@ -16,6 +16,8 @@
                     "\tpasswd - set/update/clear password\r\n" \
                     "\tlog - enable/disable logging\r\n" \
                     "\tfetch - download file from remote server\r\n" \
+                    "\tmount - mount NAND partition to drive\r\n" \
+                    "\tumount - unmount drive\r\n" \
                     "\tversion - display NXSH version\r\n" \
                     "\thelp - print this message\r\n\r\n" \
                     "\tInvoke script files by their path (./script.js)\r\n"
@@ -44,6 +46,8 @@ char *nxsh_log(int argc, char **argv);
 char *nxsh_passwd(int argc, char **argv);
 char *nxsh_fetch(int argc, char **argv, int connfd);
 char *nxsh_script(char *path, int argc, char **argv, int connfd);
+char *nxsh_mount(int argc, char **argv);
+char *nxsh_umount(int argc, char **argv);
 
 /* Behind the scenes */
 char *nxsh_cwd();

--- a/source/main.c
+++ b/source/main.c
@@ -307,6 +307,8 @@ char *nxsh_command(int connfd, char *command, int argc, char **argv) {
     else if (strcmp(command, "log") == 0) { output = nxsh_log(argc, argv); }
     else if (strcmp(command, "passwd") == 0) { output = nxsh_passwd(argc, argv); }
     else if (strcmp(command, "fetch") == 0) { output = nxsh_fetch(argc, argv, connfd); }
+    else if (strcmp(command, "mount") == 0) { output = nxsh_mount(argc, argv); }
+    else if (strcmp(command, "umount") == 0) { output = nxsh_umount(argc, argv); }
 
     // Print working directory
     else if (strcmp(command, "pwd") == 0) {

--- a/source/mount.c
+++ b/source/mount.c
@@ -1,0 +1,32 @@
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+#include <switch.h>
+#include <nxsh.h>
+
+#define MOUNT_SUCCESS "Mounted partition %s to \"%s\" successfully\r\n"
+#define UMOUNT_SUCCESS "Unmounted \"%s\" successfully\r\n"
+
+char *nxsh_mount(int argc, char **argv) {
+    if (argc < 2)
+        return error("Usage: mount [partition id] [drive name]\r\n");
+    FsFileSystem dev;
+    if (R_FAILED(fsOpenBisFileSystem(&dev, atoi(argv[0]), "")))
+        return error("Mounting failed\r\n");
+    if (fsdevMountDevice(argv[1], dev) == -1)
+        return error("Mounting failed\r\n");
+    char *success = malloc(sizeof(char) * (strlen(MOUNT_SUCCESS) - 4 + strlen(argv[0]) + strlen(argv[1])));
+    sprintf(success, MOUNT_SUCCESS, argv[0], argv[1]);
+    return success;
+}
+
+char *nxsh_umount(int argc, char **argv) {
+    if (argc < 1)
+        return error("Usage: umount [drive name]\r\n");
+    if (fsdevUnmountDevice(argv[0]) == -1)
+        return error("Unmounting failed\r\n");
+    char *success = malloc(sizeof(char) * (strlen(UMOUNT_SUCCESS) - 2 + strlen(argv[0])));
+    sprintf(success, UMOUNT_SUCCESS, argv[0]);
+    return success;
+}


### PR DESCRIPTION
You can look at NAND partitions with `mount [partition id] [drive]` and then you can do `cd drive:/` to go into that drive. To go back to the SD card, just do `cd sdmc:/`. You can find out partition ID's [here](https://switchbrew.org/wiki/Flash_Filesystem#User_Partitions). You can then unmount the drives with `umount [drive]`, but libnx will unmount all drives once the NRO is closed, or the Switch is powered off if you're using the kip.