### PR TITLE
Added more verbosity to socket bind errors and changed NXSH_PORT to 3005

### DIFF
--- a/include/nxsh.h
+++ b/include/nxsh.h
@@ -39,7 +39,7 @@
 
 #define NXSH_VERSION "0.1.8 beta"
 
-#define NXSH_PORT 23
+#define NXSH_PORT 3005
 
 extern int NXSH_LOGGING_ENABLED;
 extern int NXSH_FD_LOCK;

--- a/source/main.c
+++ b/source/main.c
@@ -41,8 +41,11 @@ int setupServerSocket(int *lissock) {
         #ifdef __SYS__
         svcSleepThread(1e+9L);
         #else
-        printf("Failed to bind: error %d\n", errno);
-        break;
+	printf("Failed to bind on port %d\n", NXSH_PORT);
+        printf("Error %d: %s\n", errno, strerror(errno));
+        consoleUpdate(NULL);
+        usleep(8000000);
+        return -1;
         #endif
     }
     


### PR DESCRIPTION
Issue: Receiving error 13, permission denied, when binding on port 23.

Description: When attempting to bind to port 23, I was receiving a permission denied error. Additionally, Instead of exiting, the program would continue and the console would display "Listening on <IP>:<NXSH_PORT>..." even though this wasn't true.

Changes: I added more verbosity to possible socket bind errors in setupServerSocket() and changed NXSH_PORT to 3005. It seems that any port below 1024 returns error 13. 